### PR TITLE
replace parsing in getTemporalScore() with a call of getVectorObject()

### DIFF
--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -75,13 +75,7 @@ function CVSS(vector) {
    * @returns {Number} Temporal  Score
    */
   function getTemporalScore() {
-    const vectorArray = vector.split("/");
-    const vectorObject = {};
-
-    for (const entry of vectorArray) {
-      const values = entry.split(":");
-      vectorObject[values[0]] = values[1];
-    }
+    const vectorObject = getVectorObject()
 
     const score = getScore();
 

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -75,7 +75,7 @@ function CVSS(vector) {
    * @returns {Number} Temporal  Score
    */
   function getTemporalScore() {
-    const vectorObject = getVectorObject()
+    const vectorObject = getVectorObject();
 
     const score = getScore();
 


### PR DESCRIPTION
# Description

The vector object was parsed in the same way in both `getVectorObject()` and `getTemporalScore()` functions. It is possible to just replace the implementation in getTemporalScore() with a call of getVectorObject().

Fixes #24 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
