### PR TITLE
fix #38: allow the user to create a vector with an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ const vector3 = CVSS(
 );
 ```
 
+It is possible to pass in an object as well
+
+```js
+const vectorObject = {
+  CVSS: "3.0",
+  AV: "N",
+  AC: "H",
+  PR: "H",
+  UI: "R",
+  S: "U",
+  C: "H",
+  I: "N",
+  A: "N"
+};
+
+console.log(CVSS(vectorObject).vector); // "CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:N/A:N"
+```
+
 To get the scores, simply call the respective function.
 
 ```js

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -335,8 +335,6 @@ function CVSS(vector) {
 
     let vectorString = "";
 
-    vectorString = "";
-
     for (const [metric, value] of Object.entries(obj)) {
       vectorString += `${metric}:${value}/`;
     }

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -322,6 +322,25 @@ function CVSS(vector) {
     return true;
   };
 
+  function parseVectorObjectToString(obj) {
+    if (typeof obj === "string") {
+      return obj;
+    }
+
+    let vectorString = "";
+
+    vectorString = "";
+
+    for (const [metric, value] of Object.entries(obj)) {
+      vectorString += `${metric}:${value}/`;
+    }
+
+    vectorString = vectorString.slice(0, -1);
+
+    return vectorString;
+  }
+
+  vector = parseVectorObjectToString(vector);
   //Check if vector format is valid
   const isValid = isVectorValid();
   if (!isValid) {

--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -322,6 +322,12 @@ function CVSS(vector) {
     return true;
   };
 
+  /**
+   * This transforms an object in the format of getVectorObject()
+   * and parses it to a CVSS comaptible string
+   *
+   * @param {Object} obj
+   */
   function parseVectorObjectToString(obj) {
     if (typeof obj === "string") {
       return obj;
@@ -341,6 +347,7 @@ function CVSS(vector) {
   }
 
   vector = parseVectorObjectToString(vector);
+
   //Check if vector format is valid
   const isValid = isVectorValid();
   if (!isValid) {

--- a/test/cvss.spec.js
+++ b/test/cvss.spec.js
@@ -315,3 +315,51 @@ describe("Detailed Vector Object Tests", () => {
     });
   });
 });
+
+describe("Create vector from object", () => {
+  it("Should return the vector as string", () => {
+    const vectorObject = {
+      CVSS: "3.0",
+      AV: "N",
+      AC: "H",
+      PR: "H",
+      UI: "R",
+      S: "U",
+      C: "H",
+      I: "N",
+      A: "N"
+    };
+
+    expect(CVSS(vectorObject).vector).toBe("CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:N/A:N");
+  });
+
+  it("Should calculate the correct scores", () => {
+    const vectorObject = {
+      CVSS: "3.0",
+      AV: "N",
+      AC: "H",
+      PR: "L",
+      UI: "R",
+      S: "U",
+      C: "H",
+      I: "H",
+      A: "H",
+      RL: "T",
+      CR: "L",
+      IR: "M",
+      AR: "H",
+      MAV: "N",
+      MAC: "L",
+      MPR: "N",
+      MUI: "R",
+      MS: "C",
+      MC: "H",
+      MI: "H",
+      MA: "H"
+    };
+
+    expect(CVSS(vectorObject).getScore()).toBe(7.1);
+    expect(CVSS(vectorObject).getTemporalScore()).toBe(6.9);
+    expect(CVSS(vectorObject).getEnvironmentalScore()).toBe(9.3);
+  });
+});


### PR DESCRIPTION
# Description

This allows the user to create vectors with objects, which is useful for creating vectors by user input.

Example:
```js
const vectorObject = {
  CVSS: "3.0",
  AV: "N",
  AC: "H",
  PR: "H",
  UI: "R",
  S: "U",
  C: "H",
  I: "N",
  A: "N"
};

console.log(CVSS(vectorObject).vector) // "CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:N/A:N"
```

Fixes #38

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
