### PR TITLE
Correct order of metrics for vector parsing

### DIFF
--- a/lib/cvss.js
+++ b/lib/cvss.js
@@ -333,10 +333,13 @@ function CVSS(vector) {
       return obj;
     }
 
-    let vectorString = "";
+    let vectorString = `CVSS:${obj["CVSS"]}/`; 
 
-    for (const [metric, value] of Object.entries(obj)) {
-      vectorString += `${metric}:${value}/`;
+    for (const entry of definitions["definitions"]) {
+      const metric = entry["abbr"];
+      if (Object.prototype.hasOwnProperty.call(obj, metric)) {
+        vectorString += `${metric}:${obj[metric]}/`;
+      }
     }
 
     vectorString = vectorString.slice(0, -1);

--- a/test/cvss.spec.js
+++ b/test/cvss.spec.js
@@ -15,6 +15,22 @@ describe("Score Tests", () => {
 
     const vector4 = CVSS("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N");
     expect(vector4.getScore()).toBe(8.2);
+
+    const vector5 = CVSS({
+      A: "N",
+      AC: "L",
+      AV: "N",
+      C: "L",
+      CVSS: "3.0",
+      E: "X",
+      I: "H",
+      PR: "N",
+      RC: "X",
+      RL: "X",
+      S: "U",
+      UI: "N"
+    });
+    expect(vector5.getScore()).toBe(8.2);
   });
 });
 
@@ -25,6 +41,22 @@ describe("Temporal Tests", () => {
 
     const vector6 = CVSS("CVSS:3.0/AV:N/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:F/RL:U/RC:X");
     expect(vector6.getTemporalScore()).toBe(5.4);
+
+    const vector7 = CVSS({
+      A: "N",
+      AC: "L",
+      AV: "N",
+      C: "L",
+      CVSS: "3.0",
+      E: "X",
+      I: "H",
+      PR: "N",
+      RC: "X",
+      RL: "X",
+      S: "U",
+      UI: "N"
+    });
+    expect(vector7.getTemporalScore()).toBe(8.2);
   });
 });
 
@@ -331,6 +363,23 @@ describe("Create vector from object", () => {
     };
 
     expect(CVSS(vectorObject).vector).toBe("CVSS:3.0/AV:N/AC:H/PR:H/UI:R/S:U/C:H/I:N/A:N");
+
+    const vectorObject1 = {
+      A: "N",
+      AC: "L",
+      AV: "N",
+      C: "L",
+      CVSS: "3.0",
+      E: "X",
+      I: "H",
+      PR: "N",
+      RC: "X",
+      RL: "X",
+      S: "U",
+      UI: "N"
+    };
+
+    expect(CVSS(vectorObject1).vector).toBe("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N/E:X/RL:X/RC:X");
   });
 
   it("Should calculate the correct scores", () => {


### PR DESCRIPTION
# Description

When the users passed an object, whose entries are not in the correct order, the parsing of that object to a vector string returned an invalid vector.

Created a new vector object having metrics in the same order as in the `cvss_3_0.json` file.

```
vectorObject = {};

    if (inputVectorObject.hasOwnProperty("CVSS")) {
      vectorObject["CVSS"] = inputVectorObject["CVSS"];
    }

    for (const entry of definitions["definitions"]) {
      const metric = entry["abbr"];
      if (inputVectorObject.hasOwnProperty(metric)) {
        vectorObject[metric] = inputVectorObject[metric];
      }
    }
```

Also updated the vector before checking if it is valid or not. Used the existing `parseVectorObjectToString` function to update the vector string.
```
vector = parseVectorObjectToString(getVectorObject());
``` 

Fixes  #42 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
